### PR TITLE
Add libswresample binding and example

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/example/go_audio_resampling/resample"
+)
+
+func main() {
+	inRate := 44100
+	outRate := 48000
+
+	r, err := resample.New(inRate, outRate)
+	if err != nil {
+		panic(err)
+	}
+	defer r.Close()
+
+	samples := make([]float32, inRate)
+	for i := range samples {
+		samples[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / float64(inRate)))
+	}
+
+	out1, err := r.Convert(samples)
+	if err != nil {
+		panic(err)
+	}
+	out2, err := r.Convert(nil)
+	if err != nil {
+		panic(err)
+	}
+	out := append(out1, out2...)
+
+	fmt.Printf("in samples: %d, out samples: %d\n", len(samples), len(out))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/go_audio_resampling
+
+go 1.24.3

--- a/resample/resample.go
+++ b/resample/resample.go
@@ -1,0 +1,88 @@
+// Package resample provides a minimal CGO binding to FFmpeg's
+// libswresample for converting mono float32 audio between sample rates.
+// See https://ffmpeg.org/doxygen/trunk/group__lswr.html for library docs.
+package resample
+
+/*
+#cgo pkg-config: libswresample libavutil
+#include <libswresample/swresample.h>
+#include <libavutil/channel_layout.h>
+#include <libavutil/samplefmt.h>
+#include <libavutil/opt.h>
+#include <libavutil/avutil.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+// Resampler wraps FFmpeg's SwrContext for mono float32 audio.
+type Resampler struct {
+	ctx     *C.struct_SwrContext
+	inRate  int
+	outRate int
+}
+
+// New creates a new Resampler converting from inRate to outRate.
+func New(inRate, outRate int) (*Resampler, error) {
+	ctx := C.swr_alloc_set_opts(nil,
+		C.long(C.AV_CH_LAYOUT_MONO), C.AV_SAMPLE_FMT_FLT, C.int(outRate),
+		C.long(C.AV_CH_LAYOUT_MONO), C.AV_SAMPLE_FMT_FLT, C.int(inRate),
+		0, nil)
+	if ctx == nil {
+		return nil, errors.New("swr_alloc_set_opts failed")
+	}
+	if ret := C.swr_init(ctx); ret < 0 {
+		C.swr_free(&ctx)
+		return nil, errors.New("swr_init failed")
+	}
+	return &Resampler{ctx: ctx, inRate: inRate, outRate: outRate}, nil
+}
+
+// Close releases the underlying SwrContext.
+func (r *Resampler) Close() {
+	if r.ctx != nil {
+		C.swr_free(&r.ctx)
+		r.ctx = nil
+	}
+}
+
+// Convert resamples the input mono float32 slice. If in is nil or empty,
+// remaining buffered samples are flushed.
+func (r *Resampler) Convert(in []float32) ([]float32, error) {
+	if r.ctx == nil {
+		return nil, errors.New("nil context")
+	}
+
+	inSamples := C.int(len(in))
+	var inBuf unsafe.Pointer
+	if len(in) > 0 {
+		inBuf = C.malloc(C.size_t(unsafe.Sizeof(uintptr(0))))
+		defer C.free(inBuf)
+		*(**C.uint8_t)(inBuf) = (*C.uint8_t)(unsafe.Pointer(&in[0]))
+	}
+
+	delay := C.swr_get_delay(r.ctx, C.int64_t(r.inRate)) + C.int64_t(inSamples)
+	outSamples := int(C.av_rescale_rnd(delay, C.int64_t(r.outRate), C.int64_t(r.inRate), C.AV_ROUND_UP))
+	out := make([]float32, outSamples)
+
+	outBuf := C.malloc(C.size_t(unsafe.Sizeof(uintptr(0))))
+	defer C.free(outBuf)
+	*(**C.uint8_t)(outBuf) = (*C.uint8_t)(unsafe.Pointer(&out[0]))
+
+	var inArg **C.uint8_t
+	if len(in) > 0 {
+		inArg = (**C.uint8_t)(inBuf)
+	}
+
+	ret := C.swr_convert(r.ctx,
+		(**C.uint8_t)(outBuf), C.int(outSamples),
+		inArg, inSamples)
+	if ret < 0 {
+		return nil, errors.New("swr_convert failed")
+	}
+	return out[:ret], nil
+}

--- a/resample/resample_test.go
+++ b/resample/resample_test.go
@@ -1,0 +1,42 @@
+package resample
+
+import (
+	"math"
+	"testing"
+)
+
+func TestResampleLength(t *testing.T) {
+	inRate, outRate := 44100, 48000
+	r, err := New(inRate, outRate)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	defer r.Close()
+
+	in := make([]float32, inRate)
+	out1, err := r.Convert(in)
+	if err != nil {
+		t.Fatalf("Convert returned error: %v", err)
+	}
+	out2, err := r.Convert(nil)
+	if err != nil {
+		t.Fatalf("flush returned error: %v", err)
+	}
+	out := append(out1, out2...)
+
+	expected := int(math.Round(float64(len(in)) * float64(outRate) / float64(inRate)))
+	if diff := int(math.Abs(float64(len(out) - expected))); diff > 1 {
+		t.Fatalf("unexpected output length: got %d want %d", len(out), expected)
+	}
+}
+
+func TestConvertAfterClose(t *testing.T) {
+	r, err := New(44100, 48000)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	r.Close()
+	if _, err := r.Convert([]float32{0}); err == nil {
+		t.Fatalf("expected error after Close")
+	}
+}


### PR DESCRIPTION
## Summary
- add CGO wrapper around libswresample for mono float32 resampling
- provide example converting 44.1 kHz sine wave to 48 kHz
- include tests for output length and error handling

## Testing
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/example`


------
https://chatgpt.com/codex/tasks/task_e_689aebd50ef08328bfd71a69f619cb75